### PR TITLE
Add normalize on service_discovery_nodes

### DIFF
--- a/src/rabbit_peer_discovery_cleanup.erl
+++ b/src/rabbit_peer_discovery_cleanup.erl
@@ -294,7 +294,7 @@ unreachable_nodes() ->
 -spec service_discovery_nodes() -> [node()].
 service_discovery_nodes() ->
     Module = rabbit_peer_discovery:backend(),
-    case Module:list_nodes() of
+    case rabbit_peer_discovery:normalize(Module:list_nodes()) of
         {ok, {Nodes, _Type}} ->
             rabbit_log:debug("Peer discovery cleanup: ~p returned ~p",
                              [Module, Nodes]),


### PR DESCRIPTION
This PR is a fix for https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/issues/6

And in general, it fixes all the `Module:list_nodes()` results
