### PR TITLE
If inet6 is defined in inetrc, use it in httpc

### DIFF
--- a/src/rabbit_peer_discovery_common_app.erl
+++ b/src/rabbit_peer_discovery_common_app.erl
@@ -21,6 +21,7 @@
 
 start(_Type, _StartArgs) ->
     rabbit_peer_discovery_httpc:maybe_configure_proxy(),
+    rabbit_peer_discovery_httpc:maybe_configure_inet6(),
     rabbit_peer_discovery_common_sup:start_link().
 
 stop(_State) ->


### PR DESCRIPTION
If the user configures `{inet6, true}` in `ERL_INETRC` file, then use it for all `httpc:` calls in peer discovery.

Fixes rabbitmq/rabbitmq-peer-discovery-k8s#55